### PR TITLE
fix: kill-switch SW + /vdiff/ generate exclude

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -220,6 +220,9 @@ export default {
     '@nuxtjs/moment',
   ],
   vuetify: {},
+  pwa: {
+    workbox: false,
+  },
   i18n: {
     locales: [
       { code: 'en', iso: 'en_US', file: 'en.json' },
@@ -294,6 +297,7 @@ export default {
 
   generate: {
     fallback: true,
+    exclude: [/^\/vdiff(\/|$)/],
     routes() {
       const baseUrl = process.env.BASE_URL
 

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,0 +1,28 @@
+// /sw.js — kill-switch Service Worker
+// 旧 @nuxtjs/pwa (workbox) で登録された SW を退役させる目的でのみ存在する。
+// 新規キャッシュは一切しない。fetch ハンドラも登録しない。
+// 退役完了後もロングテール再訪ユーザに行き渡るまで残しておくこと。
+self.addEventListener('install', () => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys()
+      await Promise.all(keys.map((k) => caches.delete(k)))
+      await self.registration.unregister()
+      const clients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+      })
+      for (const client of clients) {
+        try {
+          client.navigate(client.url)
+        } catch (_) {
+          /* noop */
+        }
+      }
+    })()
+  )
+})


### PR DESCRIPTION
## Summary
- `@nuxtjs/pwa` の workbox を無効化（旧 SW の StaleWhileRevalidate 30日キャッシュが新版反映を阻害していた）
- `static/sw.js` を kill-switch 実装に置換（cache全削除 → unregister → 開いているタブを再ナビゲート）
- `generate.exclude` に `/vdiff/` を追加（Nuxt の crawler が比較リンクを辿って Nuxt 404 ページを `static/vdiff/index.html` に上書きしていた）

## Background
- 解説記事: https://tech.ldas.jp/ja/posts/service-worker-kill-switch-after-pwa-migration
- vdiff/mirador3 の挙動差は、リンクが `process.env.BASE_URL` 前置（外部URL扱い）か相対パス（内部URL扱い）かで Nuxt crawler が辿るかどうかが分かれていたため

## Test plan
- [ ] master にマージ後、Production ワークフロー成功
- [ ] `/sw.js` が kill-switch 内容で 200 OK / `application/javascript` を返す
- [ ] `/vdiff/` が静的な vdiff デモアプリ（909B 系）を返す
- [ ] `/picture/face/` のリンクが `/vdiff/?img1=...` でパタパタ顔比較が動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)