### PR TITLE
feat: 旧SW を即時撤去するクライアントプラグインを追加

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -186,7 +186,7 @@ export default {
   /*
    ** Plugins to load before mounting the App
    */
-  plugins: [],
+  plugins: [{ src: '~/plugins/sw-cleanup.client.js', mode: 'client' }],
   /*
    ** Nuxt.js dev-modules
    */

--- a/plugins/sw-cleanup.client.js
+++ b/plugins/sw-cleanup.client.js
@@ -1,0 +1,22 @@
+// 旧 @nuxtjs/pwa (workbox) で登録された Service Worker / Cache Storage を
+// ページ訪問時に強制撤去するクライアントプラグイン。
+// /sw.js の kill-switch SW と二段構えで、ロングテール再訪ユーザの初回アクセス時に
+// 即時クリーンアップを行う。退役完了が確認できたら本ファイルは削除して良い。
+export default () => {
+  try {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations().then((registrations) => {
+        registrations.forEach((registration) => {
+          registration.unregister()
+        })
+      })
+    }
+    if (typeof caches !== 'undefined') {
+      caches.keys().then((keys) => {
+        keys.forEach((key) => caches.delete(key))
+      })
+    }
+  } catch (_) {
+    /* noop */
+  }
+}


### PR DESCRIPTION
## Summary
- \`plugins/sw-cleanup.client.js\` を追加。ページ訪問時に \`navigator.serviceWorker.getRegistrations()\` で全 SW を unregister し、\`caches.keys()\` で全 Cache Storage を削除する。
- kill-switch SW (\`/sw.js\`)のactivate を待たずに、ロングテール再訪ユーザの初回アクセス時に旧 workbox SW + cache を即時撤去する保険。
- 退役完了が確認できたら本ファイルは削除可。

## Verification
- ローカル \`NODE_ENV=production npx nuxt generate\` が完走することを確認
- bundle (\`dist/_nuxt/9c20ae3.js\`) にプラグイン内容が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)